### PR TITLE
[Chart.js] Check if chart is already connected

### DIFF
--- a/assets/src/controller.ts
+++ b/assets/src/controller.ts
@@ -40,6 +40,11 @@ export default class extends Controller {
             throw new Error('Invalid element');
         }
 
+        if(Chart.getChart(this.element)) {
+            // Chart is already connected
+            return;
+        }
+
         const payload = this.viewValue;
         if (Array.isArray(payload.options) && 0 === payload.options.length) {
             payload.options = {};


### PR DESCRIPTION
Fixes #1408

Adds an extra check if the chart is already connected and short circuits, since otherwise creating the new Chart would throw an error.